### PR TITLE
Add regex to limit NICs (IDR-0.3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Role Variables
 
 - `network_cloud_interfaces`: A list of network interfaces to be added, default is to attempt to add all.
   Existing interfaces will not be modified, even if they are in this list.
+- `network_cloud_interface_regex`: A regular expression used to match interfaces to be activated, default `.*`.
+  An example use is on Docker servers where you want to ignore virtual interfaces.
 
 
 Author Information

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Role Variables
   An example use is on Docker servers where you want to ignore virtual interfaces.
 
 
+Example playbook
+----------------
+
+    - hosts: cloud-instance
+      roles:
+      - role: network-cloud-interfaces
+        network_cloud_interface_regex: '^eth.*'
+
+
 Author Information
 ------------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for roles/network-cloud-interfaces
+
+network_cloud_interface_regex: '.*'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,11 @@
          "/etc/sysconfig/network-scripts/ifcfg-" + item)
          | list | length) == 0
     }}
-  with_items: "{{ network_cloud_interfaces | default(ansible_interfaces) }}"
+  with_items: >
+    {{
+      network_cloud_interfaces | default(ansible_interfaces) |
+      select('search', network_cloud_interface_regex) | list
+    }}
   register: network_cloud_modified
 
 - name: network cloud | disable default routes


### PR DESCRIPTION
If this role is applied to an existing docker server with active containers it'll attempt to process the virtual docker interfaces. This PR adds a regex to limit the processed interfaces (default is `.*` so the default behaviour is unchanged).