### PR TITLE
Disable /etc/resolv.conf for additional NICs

### DIFF
--- a/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -5,3 +5,4 @@ ONBOOT=yes
 TYPE=Ethernet
 USERCTL=no
 DEFROUTE=no
+PEERDNS=no


### PR DESCRIPTION
This prevents additional NICs from modifying `/etc/resolv.conf`, potentially with incorrect nameservers, when initialised from DHCP.