### PR TITLE
Fix deprecated tests as filter

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,6 @@
 - name: network cloud | start new nics
   become: true
   command: /usr/sbin/ifup {{ item.item }}
-  when: item | changed
+  when: item is changed
   with_items:
     - "{{ network_cloud_modified.results }}"


### PR DESCRIPTION
Fixes #5 

Currently tested in the deployment of `test104`